### PR TITLE
database version check

### DIFF
--- a/FastPlaz/src/helper/string_helpers.pas
+++ b/FastPlaz/src/helper/string_helpers.pas
@@ -56,7 +56,6 @@ type
     function Split( ADelimiter: string = ','): TStrings; overload; inline;
     function StrPos( AText: string): integer; overload; inline;
     function Quoted( AQuote: char = ''''): string; overload; inline;
-
   end;
 
 implementation

--- a/FastPlaz/src/library/common.pas
+++ b/FastPlaz/src/library/common.pas
@@ -56,6 +56,7 @@ const
   _DATABASE_DATABASENAME = 'database/%s/database_name';
   _DATABASE_TABLE_PREFIX = 'database/%s/prefix';
   _DATABASE_LIBRARY = 'database/%s/library';
+  _DATABASE_VERSION_CHECK = 'database/%s/version_check';
 
   _MAIL_MAILSERVER = 'mailer/%s/hostname';
   _MAIL_USERNAME = 'mailer/%s/username';

--- a/FastPlaz/src/systems/fastplaz_handler.pas
+++ b/FastPlaz/src/systems/fastplaz_handler.pas
@@ -84,6 +84,7 @@ type
     hitStorage: string;
     databaseRead,
     databaseWrite: string;
+    databaseVersionCheck,
     databaseActive,
     useDatabase,
     initialized,

--- a/tools/templates/api/config/config.json
+++ b/tools/templates/api/config/config.json
@@ -18,7 +18,7 @@
   },
   "database" : {
     "default" : {
-      "driver" : "MySQL 5.7",
+      "driver" : "MySQL 8.0",
       "hostname" : "localhost",
       "port" : "",
       "username" : "your_username",
@@ -26,6 +26,7 @@
       "database_name" : "your_database",
       "charset" : "",
       "prefix" : "",
+      "version_check": false,
       "library" : "..\/libs\/win\/libmysql.dll"
     }
   },

--- a/tools/templates/packages/Simple/public_html/config/config.json
+++ b/tools/templates/packages/Simple/public_html/config/config.json
@@ -18,7 +18,7 @@
   },
   "database" : {
     "default" : {
-      "driver" : "MySQL 5.7",
+      "driver" : "MySQL 8.0",
       "hostname" : "localhost",
       "port" : "",
       "username" : "your_username",
@@ -26,6 +26,7 @@
       "database_name" : "the_database_name",
       "charset" : "",
       "prefix" : "",
+      "version_check": false,
       "library" : ""
     }
   },

--- a/tools/templates/web/config/config.json
+++ b/tools/templates/web/config/config.json
@@ -18,7 +18,7 @@
   },
   "database" : {
     "default" : {
-      "driver" : "MySQL 5.7",
+      "driver" : "MySQL 8.0",
       "hostname" : "localhost",
       "port" : "",
       "username" : "your_username",
@@ -26,6 +26,7 @@
       "database_name" : "your_database",
       "charset" : "",
       "prefix" : "",
+      "version_check": false,
       "library" : "..\/libs\/win\/libmysql.dll"
     }
   },


### PR DESCRIPTION
Added configuration field to skip database version check:

```json
  "database" : {
    "default" : {
      "driver" : "MySQL 8.0",
      "hostname" : "127.0.0.1",
      "port" : "",
      "username" : "username",
      "password" : "password",
      "database_name" : "your_database",
      "charset" : "",
      "prefix" : "",
      "version_check": true,
      "library" : "your-path\\mysql-8.0.26\\lib\\libmysql.dll"
    },

```