### PR TITLE
Update database_lib.pas

### DIFF
--- a/FastPlaz/src/library/database_lib.pas
+++ b/FastPlaz/src/library/database_lib.pas
@@ -705,7 +705,10 @@ begin
   Result := 0;
   try
     if Data.Active then Data.Close;
-    Data.SQL.Text := 'SELECT LAST_INSERT_ID() as lastid FROM ' + TableName;
+    if (SameText(Config['database/default/driver'], 'postgresql')) then
+      Data.SQL.Text := 'SELECT lastval() AS lastid'
+    else
+      Data.SQL.Text := 'SELECT LAST_INSERT_ID() as lastid FROM ' + TableName;
     Data.Open;
     if Data.RecordCount > 0 then
       Result := Data.FieldValues['lastid'];


### PR DESCRIPTION
Function:
TSimpleModel.GetLastInsertID

Current implementation always executes

SELECT LAST_INSERT_ID()

which is only available in MySQL.

For PostgreSQL it should execute

SELECT lastval()

instead.

I have implemented and tested both fixes successfully using PostgreSQL. I will submit a Pull Request with the implementation.

Closes <!-- mention the issue that you're trying to close with this PR -->

## Description

<!-- Describe your implementation plan and approach -->

## Current Tasks

<!-- (Optional) List the tasks that you're planning to do in this PR.
This is to indicate how much you have been progressing before this PR is ready for review -->

- [ ] (task 1)
- [ ] (task 2)
- [ ] (task 3)
