### PR TITLE
Update session_controller.pas

### DIFF
--- a/FastPlaz/src/systems/session_controller.pas
+++ b/FastPlaz/src/systems/session_controller.pas
@@ -29,6 +29,19 @@ const
   _SESSION_SQL_UPDATE =
     'REPLACE INTO session_info ( sessid, ipaddr, lastused, uid, remember, vars) VALUES( "%s", "%s", UNIX_TIMESTAMP(now()), %d, %d, "%s");';
 
+  _SESSION_SQL_UPDATE_PG =
+    'INSERT INTO session_info '+
+    '(sessid, ipaddr, lastused, uid, remember, vars) '+
+    'VALUES ('+
+    ' ''%s'', ''%s'', CAST(EXTRACT(EPOCH FROM now()) AS BIGINT), %d, %d, ''%s'' '+
+    ') '+
+    'ON CONFLICT (sessid) DO UPDATE SET '+
+    ' ipaddr = EXCLUDED.ipaddr,'+
+    ' lastused = EXCLUDED.lastused,'+
+    ' uid = EXCLUDED.uid,'+
+    ' remember = EXCLUDED.remember,'+
+    ' vars = EXCLUDED.vars;';
+
 type
 
   { TSessionController }
@@ -107,7 +120,7 @@ type
 
 implementation
 
-uses logutil_lib, common, session_model;
+uses logutil_lib, common, session_model, fastplaz_handler;
 
 //uses common; --- failed jk memasukkan common ke unit ini
 
@@ -330,8 +343,15 @@ begin
   if remoteAddr.IsEmpty then
     remoteAddr := Application.EnvironmentVariable['REMOTE_ADDR'];
   uid := s2i(FSessionVars.Values[SESSION_FIELD_UID]);
-  sql := Format(_SESSION_SQL_UPDATE, [FSessionID, remoteAddr,
+  if (SameText(Config['database/default/driver'], 'postgresql')) then
+  begin
+    sql := Format(_SESSION_SQL_UPDATE_PG, [FSessionID, remoteAddr,
     uid, 0, c(FSessionVars.Text)]);
+  end else
+  begin
+    sql := Format(_SESSION_SQL_UPDATE, [FSessionID, remoteAddr,
+    uid, 0, c(FSessionVars.Text)]);
+  end;
   Result := SessionTable.Exec(sql);
 end;
 


### PR DESCRIPTION
I found two PostgreSQL compatibility issues while testing FastPlaz with PostgreSQL.

Issue 1
Function:
TSessionController.UpdateDatabase

Current implementation uses:

- REPLACE INTO
- UNIX_TIMESTAMP(now())

These are MySQL-specific SQL statements and cause errors on PostgreSQL.

Suggested solution:
Use

INSERT ... ON CONFLICT (sessid) DO UPDATE

and

EXTRACT(EPOCH FROM now())

instead.

Closes <!-- mention the issue that you're trying to close with this PR -->

## Description

<!-- Describe your implementation plan and approach -->

## Current Tasks

<!-- (Optional) List the tasks that you're planning to do in this PR.
This is to indicate how much you have been progressing before this PR is ready for review -->

- [ ] (task 1)
- [ ] (task 2)
- [ ] (task 3)
