### PR TITLE
ci: simplify updater workflows, remove unused node/yarn setup

### DIFF
--- a/.github/workflows/updater-development.yml
+++ b/.github/workflows/updater-development.yml
@@ -1,4 +1,4 @@
-name: Update Logger
+name: Update Logger (Development)
 
 on:
   push:
@@ -7,50 +7,24 @@ on:
 
 jobs:
   generate_update:
-
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - name: work around permission issue
-        run: git config --global --add safe.directory /github/workspace
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-         persist-credentials: false
-         fetch-depth: 0
+          fetch-depth: 0
 
-      - name: Use node 16
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-
-      - name: Get yarn cache
-        id: yarn-cache
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-        #run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Cache Node.js modules
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.OS }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.OS }}-yarn-
-            
       - name: Modify last update
         run: |
-          d=`date '+%Y-%m-%dT%H:%M:%SZ'`
-          echo $d > LAST_UPDATED_DEVELOPMENT
-          
-      - name: Commit files report
+          d=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+          echo "$d" > LAST_UPDATED_DEVELOPMENT
+
+      - name: Commit & push
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add -A
-          git commit -m "[Github Actions]: Modify last update"
-          
-      - name: GitHub Push
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.ref }}
-          force: true
+          git config user.email "action@github.com"
+          git config user.name "GitHub Action"
+          git add LAST_UPDATED_DEVELOPMENT
+          git commit -m "[Github Actions]: Modify last update" || exit 0
+          git push

--- a/.github/workflows/updater-master.yml
+++ b/.github/workflows/updater-master.yml
@@ -1,4 +1,4 @@
-name: Update Logger
+name: Update Logger (Master)
 
 on:
   push:
@@ -7,50 +7,24 @@ on:
 
 jobs:
   generate_update:
-
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - name: work around permission issue
-        run: git config --global --add safe.directory /github/workspace
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-         persist-credentials: false
-         fetch-depth: 0
+          fetch-depth: 0
 
-      - name: Use node 16
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-
-      - name: Get yarn cache
-        id: yarn-cache
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-        #run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Cache Node.js modules
-        uses: actions/cache@v1
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.OS }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.OS }}-yarn-
-            
       - name: Modify last update
         run: |
-          d=`date '+%Y-%m-%dT%H:%M:%SZ'`
-          echo $d > LAST_UPDATED
-          
-      - name: Commit files report
+          d=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+          echo "$d" > LAST_UPDATED
+
+      - name: Commit & push
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add -A
-          git commit -m "[Github Actions]: Modify last update"
-          
-      - name: GitHub Push
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.ref }}
-          force: true
+          git config user.email "action@github.com"
+          git config user.name "GitHub Action"
+          git add LAST_UPDATED
+          git commit -m "[Github Actions]: Modify last update" || exit 0
+          git push


### PR DESCRIPTION
- remove setup-node@v3 (Node 16 EOL, never used to run any JS)
- remove yarn cache + actions/cache steps (no yarn.lock in repo)
- remove ad-m/github-push-action@master in favor of native git push
- remove hardcoded safe.directory /github/workspace workaround
- upgrade actions/checkout@v3 -> @v4
- drop force: true on push
- add permissions: contents: write (least privilege)
- use date -u for explicit UTC, quote variables, scope git add
