### PR TITLE
refactor(session): detect db driver via ConnectorType to avoid potential circular-reference

### DIFF
--- a/FastPlaz/src/library/database_lib.pas
+++ b/FastPlaz/src/library/database_lib.pas
@@ -147,6 +147,7 @@ type
     function Open( AUniDirectional:Boolean = False): Boolean;
   published
     property Debug: boolean read FDebug write FDebug;
+    property Connector: TSQLConnector read FConnector;
   end;
 
 function DataBaseInit( const RedirecURL:string = ''; const DBConfigName: string = ''):boolean;
@@ -746,7 +747,7 @@ begin
   Result := 0;
   try
     if Data.Active then Data.Close;
-    if (SameText(Config['database/default/driver'], 'postgresql')) then
+    if DB_Connector.ConnectorType.ToLower.StartsWith('postgre') then
       Data.SQL.Text := 'SELECT lastval() AS lastid'
     else
       Data.SQL.Text := 'SELECT LAST_INSERT_ID() as lastid FROM ' + TableName;

--- a/FastPlaz/src/systems/session_controller.pas
+++ b/FastPlaz/src/systems/session_controller.pas
@@ -120,7 +120,7 @@ type
 
 implementation
 
-uses logutil_lib, common, session_model, fastplaz_handler;
+uses logutil_lib, common, session_model;
 
 //uses common; --- failed jk memasukkan common ke unit ini
 
@@ -343,7 +343,7 @@ begin
   if remoteAddr.IsEmpty then
     remoteAddr := Application.EnvironmentVariable['REMOTE_ADDR'];
   uid := s2i(FSessionVars.Values[SESSION_FIELD_UID]);
-  if (SameText(Config['database/default/driver'], 'postgresql')) then
+  if SessionTable.Connector.ConnectorType.ToLower.StartsWith('postgre') then
   begin
     sql := Format(_SESSION_SQL_UPDATE_PG, [FSessionID, remoteAddr,
     uid, 0, c(FSessionVars.Text)]);


### PR DESCRIPTION

- expose TSimpleModel.FConnector via public property Connector in database_lib
- replace Config['database/default/driver'] check with SessionTable.Connector.ConnectorType in session_controller.UpdateDatabase and TSimpleModel.GetLastInsertID
- drop fastplaz_handler from session_controller uses to prevent potential circular-reference problem (fastplaz_handler already uses session_controller in its interface section)
